### PR TITLE
[network][feat] 테마 상세보기 뷰 - 서버 연결 및 기능 추가

### DIFF
--- a/boardpedia/boardpedia.xcodeproj/project.pbxproj
+++ b/boardpedia/boardpedia.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		9B634A3D2680A4B8005ADCC3 /* SearchGameData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B634A3C2680A4B8005ADCC3 /* SearchGameData.swift */; };
 		9B634A442682352F005ADCC3 /* TabBar.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9B634A432682352F005ADCC3 /* TabBar.storyboard */; };
 		9B634A472682355E005ADCC3 /* TabBarVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B634A462682355E005ADCC3 /* TabBarVC.swift */; };
+		9B652C5326AC3E9C00DC7931 /* ThemeDetailData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B652C5226AC3E9C00DC7931 /* ThemeDetailData.swift */; };
 		9B7F182E2666277B00BD29CC /* GameDetailData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B7F182D2666277B00BD29CC /* GameDetailData.swift */; };
 		9B7F18332668AF7400BD29CC /* SimilarGameCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B7F18322668AF7400BD29CC /* SimilarGameCell.swift */; };
 		9B7F18362668C88800BD29CC /* GameReviewVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B7F18352668C88800BD29CC /* GameReviewVC.swift */; };
@@ -138,6 +139,7 @@
 		9B634A3C2680A4B8005ADCC3 /* SearchGameData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchGameData.swift; sourceTree = "<group>"; };
 		9B634A432682352F005ADCC3 /* TabBar.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = TabBar.storyboard; sourceTree = "<group>"; };
 		9B634A462682355E005ADCC3 /* TabBarVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarVC.swift; sourceTree = "<group>"; };
+		9B652C5226AC3E9C00DC7931 /* ThemeDetailData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeDetailData.swift; sourceTree = "<group>"; };
 		9B7F182D2666277B00BD29CC /* GameDetailData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameDetailData.swift; sourceTree = "<group>"; };
 		9B7F18322668AF7400BD29CC /* SimilarGameCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimilarGameCell.swift; sourceTree = "<group>"; };
 		9B7F18352668C88800BD29CC /* GameReviewVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameReviewVC.swift; sourceTree = "<group>"; };
@@ -367,6 +369,7 @@
 			children = (
 				9B41FA9826467FBC002A3E13 /* GameData.swift */,
 				9BE098CB26490AB2007D2BEC /* ThemeData.swift */,
+				9B652C5226AC3E9C00DC7931 /* ThemeDetailData.swift */,
 				9BE098E6264995A6007D2BEC /* KeywordData.swift */,
 				9BE098FA264A6AEA007D2BEC /* SearchResultData.swift */,
 				9B9C53CA264D23C900C6A01C /* MyReviewData.swift */,
@@ -730,6 +733,7 @@
 				9BD72CD22671EA8900CE299C /* APITarget.swift in Sources */,
 				9B294193267A4A420008F69F /* SplashVC.swift in Sources */,
 				9B4ACDD0266B688A00381416 /* NetworkResult.swift in Sources */,
+				9B652C5326AC3E9C00DC7931 /* ThemeDetailData.swift in Sources */,
 				9B4FFE3B267F355700797E96 /* MainNaviVC.swift in Sources */,
 				9BE098E026498C52007D2BEC /* UITextField+Extension.swift in Sources */,
 				9BE098C926490A01007D2BEC /* ThemeGameCell.swift in Sources */,

--- a/boardpedia/boardpedia/Global/Model/ThemeDetailData.swift
+++ b/boardpedia/boardpedia/Global/Model/ThemeDetailData.swift
@@ -1,0 +1,13 @@
+//
+//  ThemeDetailData.swift
+//  boardpedia
+//
+//  Created by 김민희 on 2021/07/24.
+//
+
+import Foundation
+
+struct ThemeDetailData: Codable {
+    let themes: [ThemeData]
+    let themeGame: [SearchGameData]
+}

--- a/boardpedia/boardpedia/Global/Service/APIService.swift
+++ b/boardpedia/boardpedia/Global/Service/APIService.swift
@@ -52,6 +52,14 @@ struct APIService {
         
     }
     
+    func todayThemeDetail(_ jwt: String, _index: Int, completion: @escaping (NetworkResult<ThemeDetailData>)->(Void)) {
+        // 오늘의 테마 상세보기
+        
+        let target: APITarget = .themeDetail(jwt: jwt, index: _index)
+        judgeObject(target, completion: completion)
+        
+    }
+    
     func searchResult(_ jwt: String, _ inputWord: String, completion: @escaping (NetworkResult<[SearchGameData]>)->(Void)) {
         // 검색 결과
         

--- a/boardpedia/boardpedia/Global/Service/APIService.swift
+++ b/boardpedia/boardpedia/Global/Service/APIService.swift
@@ -52,10 +52,10 @@ struct APIService {
         
     }
     
-    func todayThemeDetail(_ jwt: String, _index: Int, completion: @escaping (NetworkResult<ThemeDetailData>)->(Void)) {
+    func todayThemeDetail(_ jwt: String, _ index: Int, completion: @escaping (NetworkResult<ThemeDetailData>)->(Void)) {
         // 오늘의 테마 상세보기
         
-        let target: APITarget = .themeDetail(jwt: jwt, index: _index)
+        let target: APITarget = .themeDetail(jwt: jwt, index: index)
         judgeObject(target, completion: completion)
         
     }

--- a/boardpedia/boardpedia/Screen/Main/Cell/ThemeCollectionReusableView.swift
+++ b/boardpedia/boardpedia/Screen/Main/Cell/ThemeCollectionReusableView.swift
@@ -49,7 +49,9 @@ class ThemeCollectionReusableView: UICollectionReusableView {
         
     }
     
-    func setTheme(info: String, title: String) {
+    func setTheme(info: String, title: String, back: String) {
+        
+        backImageView.setImage(from: back)
         infoLabel.text = info
         themeTitleLabel.text = title
     }

--- a/boardpedia/boardpedia/Screen/Main/Cell/ThemeCollectionReusableView.swift
+++ b/boardpedia/boardpedia/Screen/Main/Cell/ThemeCollectionReusableView.swift
@@ -121,6 +121,8 @@ extension ThemeCollectionReusableView: UICollectionViewDataSource {
         if let data = themeKeywordData {
             cell.configure(title: data[indexPath.row])
         }
+        
+        cell.contentView.setRounded(radius: 13)
     
         return cell
     }

--- a/boardpedia/boardpedia/Screen/Main/Cell/ThemeCollectionReusableView.swift
+++ b/boardpedia/boardpedia/Screen/Main/Cell/ThemeCollectionReusableView.swift
@@ -12,12 +12,14 @@ class ThemeCollectionReusableView: UICollectionReusableView {
     // MARK: Variable Part
     
     var themeKeywordData: [KeywordData] = []
+    var backButtonAction : (() -> Void)? // closer 변수
  
     // MARK: IBOutlet
     
     @IBOutlet weak var backImageView: UIImageView!
     @IBOutlet weak var infoLabel: UILabel!
     @IBOutlet weak var themeTitleLabel: UILabel!
+    @IBOutlet weak var backButton: UIButton!
     
     @IBOutlet weak var keywordCollectionView: UICollectionView!
     
@@ -30,6 +32,8 @@ class ThemeCollectionReusableView: UICollectionReusableView {
     // MARK: ContentView Default Set Function
     
     override func awakeFromNib() {
+        
+        backButton.addTarget(self, action: #selector(backButtonDidTap(_:)), for: .touchUpInside)
         
         infoLabel.setLabel(text: "", color: .boardWhite, font: .neoMedium(ofSize: 17))
         themeTitleLabel.setLabel(text: "", color: .boardWhite, font: .neoBold(ofSize: 24))
@@ -54,6 +58,16 @@ class ThemeCollectionReusableView: UICollectionReusableView {
         backImageView.setImage(from: back)
         infoLabel.text = info
         themeTitleLabel.text = title
+    }
+    
+    @objc func backButtonDidTap(_ sender : UIButton) {
+        
+        guard let pagePluginButtonAction = backButtonAction else {
+            return
+        }
+        
+        pagePluginButtonAction()
+        // 전달받은 action 실행
     }
     
 }

--- a/boardpedia/boardpedia/Screen/Main/Cell/ThemeCollectionReusableView.swift
+++ b/boardpedia/boardpedia/Screen/Main/Cell/ThemeCollectionReusableView.swift
@@ -11,7 +11,7 @@ class ThemeCollectionReusableView: UICollectionReusableView {
     
     // MARK: Variable Part
     
-    var themeKeywordData: [KeywordData] = []
+    var themeKeywordData: [String]?
     var backButtonAction : (() -> Void)? // closer 변수
  
     // MARK: IBOutlet
@@ -45,11 +45,6 @@ class ThemeCollectionReusableView: UICollectionReusableView {
         let layout = keywordCollectionView.collectionViewLayout as! UICollectionViewFlowLayout
         layout.scrollDirection = .vertical
         
-        let item1 = KeywordData(keyword: "스피드")
-        let item2 = KeywordData(keyword: "파티")
-        let item3 = KeywordData(keyword: "즐거운")
-        
-        themeKeywordData.append(contentsOf: [item1,item2,item3])
         
     }
     
@@ -58,6 +53,11 @@ class ThemeCollectionReusableView: UICollectionReusableView {
         backImageView.setImage(from: back)
         infoLabel.text = info
         themeTitleLabel.text = title
+    }
+    
+    func setTag(tag: [String]) {
+        themeKeywordData = tag
+        keywordCollectionView.reloadData()
     }
     
     @objc func backButtonDidTap(_ sender : UIButton) {
@@ -109,7 +109,7 @@ extension ThemeCollectionReusableView: UICollectionViewDelegateFlowLayout {
 extension ThemeCollectionReusableView: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         
-        return themeKeywordData.count
+        return themeKeywordData?.count ?? 0
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -117,7 +117,10 @@ extension ThemeCollectionReusableView: UICollectionViewDataSource {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ThemeKeywordCell.identifier, for: indexPath) as? ThemeKeywordCell else {
             return UICollectionViewCell()
         }
-        cell.configure(title: themeKeywordData[indexPath.row].keyword)
+        
+        if let data = themeKeywordData {
+            cell.configure(title: data[indexPath.row])
+        }
     
         return cell
     }

--- a/boardpedia/boardpedia/Screen/Main/Cell/ThemeGameListCell.swift
+++ b/boardpedia/boardpedia/Screen/Main/Cell/ThemeGameListCell.swift
@@ -32,9 +32,9 @@ class ThemeGameListCell: UICollectionViewCell {
     
     // MARK: Data Set Function
     
-    func configure(image: String, name: String, info: String, star: Float, save: Int) {
+    func configure(image: String, name: String, info: String, star: Double, save: Int) {
 
-        gameImageView.image = UIImage(named: image)
+        gameImageView.setImage(from: image)
         gameNameLabel.setLabel(text: name, font: .neoMedium(ofSize: 16))
         gameInfoLabel.setLabel(text: info, color: .boardGray50, font: .neoRegular(ofSize: 13))
         gameValueLabel.setLabel(text: "별점 \(star) / 저장 \(save)회", color: .boardGray40, font: .neoMedium(ofSize: 12))

--- a/boardpedia/boardpedia/Screen/Main/Cell/ThemeGameListCell.swift
+++ b/boardpedia/boardpedia/Screen/Main/Cell/ThemeGameListCell.swift
@@ -9,13 +9,27 @@ import UIKit
 
 class ThemeGameListCell: UICollectionViewCell {
     
+    // MARK: Variable Part
+    
     static let identifier = "ThemeGameListCell"
+    var cellDelegate: BookmarkCellDelegate?
+    var cellIndex: IndexPath?
+    var impactFeedbackGenerator: UIImpactFeedbackGenerator?
+    
+    // MARK: IBOutlet
     
     @IBOutlet weak var gameImageView: UIImageView!
     @IBOutlet weak var gameNameLabel: UILabel!
     @IBOutlet weak var gameInfoLabel: UILabel!
     @IBOutlet weak var bookmarkButton: UIButton!
     @IBOutlet weak var gameValueLabel: UILabel!
+    
+    // MARK: IBAction
+    
+    @IBAction func bookmarkButtonDidTap(_ sender: Any) {
+        cellDelegate?.BookmarkCellGiveIndex(self, didClickedIndex: cellIndex?.row ?? 0)
+        self.impactFeedbackGenerator?.impactOccurred()
+    }
     
     // MARK: ContentView Default Set Function
     
@@ -28,6 +42,8 @@ class ThemeGameListCell: UICollectionViewCell {
         gameNameLabel.numberOfLines = 0
         gameInfoLabel.numberOfLines = 0
         gameImageView.setRounded(radius: 6)
+        
+        self.impactFeedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
     }
     
     // MARK: Data Set Function

--- a/boardpedia/boardpedia/Screen/Main/Storyboard/Base.lproj/Main.storyboard
+++ b/boardpedia/boardpedia/Screen/Main/Storyboard/Base.lproj/Main.storyboard
@@ -624,6 +624,7 @@
                                         <constraint firstAttribute="trailing" secondItem="1cQ-44-pQB" secondAttribute="trailing" constant="16" id="xwq-Q6-D6r"/>
                                     </constraints>
                                     <connections>
+                                        <outlet property="backButton" destination="StB-7M-sMs" id="oeT-jg-7QZ"/>
                                         <outlet property="backImageView" destination="iWD-4C-Sf3" id="fX6-c0-eFU"/>
                                         <outlet property="collectionLayout" destination="yEg-cd-wU6" id="m3h-LL-RNG"/>
                                         <outlet property="infoLabel" destination="1g2-cs-x8u" id="UBC-hf-X24"/>

--- a/boardpedia/boardpedia/Screen/Main/Storyboard/Base.lproj/Main.storyboard
+++ b/boardpedia/boardpedia/Screen/Main/Storyboard/Base.lproj/Main.storyboard
@@ -482,6 +482,9 @@
                                                     <state key="normal">
                                                         <imageReference key="image" image="icStorageUnselected" symbolScale="large"/>
                                                     </state>
+                                                    <connections>
+                                                        <action selector="bookmarkButtonDidTap:" destination="x4J-UD-r46" eventType="touchUpInside" id="ej0-RK-L1M"/>
+                                                    </connections>
                                                 </button>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icStar" translatesAutoresizingMaskIntoConstraints="NO" id="c3i-51-W9P">
                                                     <rect key="frame" x="175" y="140" width="15" height="15"/>

--- a/boardpedia/boardpedia/Screen/Main/Storyboard/Base.lproj/Main.storyboard
+++ b/boardpedia/boardpedia/Screen/Main/Storyboard/Base.lproj/Main.storyboard
@@ -148,6 +148,9 @@
                                                     </imageView>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rdo-wq-3JD">
                                                         <rect key="frame" x="0.0" y="0.0" width="382" height="216"/>
+                                                        <connections>
+                                                            <action selector="bestThemeButtonDidTap:" destination="BYZ-38-t0r" eventType="touchUpInside" id="peW-wJ-ZpN"/>
+                                                        </connections>
                                                     </button>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NuL-ie-icb">
                                                         <rect key="frame" x="20" y="20" width="342" height="20.5"/>
@@ -475,7 +478,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PYL-Mq-NQ4">
-                                                    <rect key="frame" x="368" y="10" width="36" height="36"/>
+                                                    <rect key="frame" x="368" y="12" width="36" height="36"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" secondItem="PYL-Mq-NQ4" secondAttribute="height" multiplier="1:1" id="opq-Q6-ooT"/>
                                                     </constraints>
@@ -504,7 +507,7 @@
                                                 <constraint firstItem="mcH-8g-bL5" firstAttribute="leading" secondItem="hp9-rb-Uty" secondAttribute="leading" constant="10" id="1DC-7E-gc5"/>
                                                 <constraint firstItem="PYL-Mq-NQ4" firstAttribute="width" secondItem="PYL-Mq-NQ4" secondAttribute="height" multiplier="1:1" id="1iV-Z9-7UN"/>
                                                 <constraint firstItem="wXu-ci-hcy" firstAttribute="leading" secondItem="mcH-8g-bL5" secondAttribute="trailing" constant="15" id="5mu-nB-bhR"/>
-                                                <constraint firstItem="PYL-Mq-NQ4" firstAttribute="top" secondItem="wXu-ci-hcy" secondAttribute="top" constant="-5" id="6sB-Ez-qXe"/>
+                                                <constraint firstItem="PYL-Mq-NQ4" firstAttribute="top" secondItem="wXu-ci-hcy" secondAttribute="top" constant="-3" id="6sB-Ez-qXe"/>
                                                 <constraint firstItem="c3i-51-W9P" firstAttribute="leading" secondItem="mcH-8g-bL5" secondAttribute="trailing" constant="15" id="A5N-A7-Xmg"/>
                                                 <constraint firstItem="PYL-Mq-NQ4" firstAttribute="height" secondItem="mcH-8g-bL5" secondAttribute="height" multiplier="24/100" id="LK0-SH-OYs"/>
                                                 <constraint firstItem="sVQ-K6-DNa" firstAttribute="leading" secondItem="c3i-51-W9P" secondAttribute="trailing" constant="5" id="Pr5-aQ-meR"/>

--- a/boardpedia/boardpedia/Screen/Main/VC/MainVC.swift
+++ b/boardpedia/boardpedia/Screen/Main/VC/MainVC.swift
@@ -331,8 +331,8 @@ extension MainVC: UICollectionViewDataSource {
             
             self.navigationController?.pushViewController(themeVC, animated: true)
             // 테마 뷰로 이동
-            themeVC.themeData = todayThemeData[indexPath.row+1]
-            // 클릭한 테마에 대한 정보 전달
+            themeVC.themeIdx = todayThemeData[indexPath.row+1].themeIdx
+            // 클릭한 테마 themeIdx 전달
         }
         
     }

--- a/boardpedia/boardpedia/Screen/Main/VC/MainVC.swift
+++ b/boardpedia/boardpedia/Screen/Main/VC/MainVC.swift
@@ -54,6 +54,19 @@ class MainVC: UIViewController {
         
     }
     
+    
+    @IBAction func bestThemeButtonDidTap(_ sender: Any) {
+        
+        guard let themeVC = self.storyboard?.instantiateViewController(identifier: "ThemeVC") as? ThemeVC else {
+            return
+        }
+        
+        self.navigationController?.pushViewController(themeVC, animated: true)
+        // 테마 뷰로 이동
+        themeVC.themeIdx = todayThemeData[0].themeIdx
+        // 클릭한 테마 themeIdx 전달
+    }
+    
     // MARK: Life Cycle Part
     
     override func viewDidLoad() {

--- a/boardpedia/boardpedia/Screen/Main/VC/MainVC.swift
+++ b/boardpedia/boardpedia/Screen/Main/VC/MainVC.swift
@@ -319,6 +319,24 @@ extension MainVC: UICollectionViewDataSource {
         
     }
     
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        // collectionView Cell 클릭 시
+        
+        if collectionView == themeGameCollectionView {
+            // 테마 콜렉션 뷰라면?
+            
+            guard let themeVC = self.storyboard?.instantiateViewController(identifier: "ThemeVC") as? ThemeVC else {
+                return
+            }
+            
+            self.navigationController?.pushViewController(themeVC, animated: true)
+            // 테마 뷰로 이동
+            themeVC.themeData = todayThemeData[indexPath.row+1]
+            // 클릭한 테마에 대한 정보 전달
+        }
+        
+    }
+    
 }
 
 extension MainVC: BookmarkCellDelegate {

--- a/boardpedia/boardpedia/Screen/Main/VC/ThemeVC.swift
+++ b/boardpedia/boardpedia/Screen/Main/VC/ThemeVC.swift
@@ -11,7 +11,6 @@ class ThemeVC: UIViewController {
     
     // MARK: Variable Part
     
-    var searchResultData: [SearchResultData] = []
     var themeDetailData: ThemeDetailData?
     var themeIdx: Int?
     
@@ -43,11 +42,15 @@ extension ThemeVC {
         
         if let token = UserDefaults.standard.string(forKey: "UserToken"),
            let index = themeIdx {
+            // 테마 받아오는 서버 연결
+            
             APIService.shared.todayThemeDetail(token, index) { [self] result in
                 switch result {
                 
                 case .success(let data):
                     themeDetailData = data
+                    themeListCollectionView.reloadData()
+                    // 데이터 화면에 뿌려주기
                     
                 case .failure(let error):
                     print(error)
@@ -57,7 +60,6 @@ extension ThemeVC {
             }
             
         }
-        //todayThemeDetail
     }
 }
 
@@ -98,15 +100,23 @@ extension ThemeVC: UICollectionViewDelegateFlowLayout {
 
 extension ThemeVC: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return searchResultData.count
+        
+        if let data = themeDetailData?.themeGame {
+            return data.count
+        }
+        
+        return 0
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ThemeGameListCell.identifier, for: indexPath) as? ThemeGameListCell else {
             return UICollectionViewCell()
         }
         
-        cell.configure(image: searchResultData[indexPath.row].gameImage, name: searchResultData[indexPath.row].gameName, info: searchResultData[indexPath.row].gameInfo, star: searchResultData[indexPath.row].startNumber, save: searchResultData[indexPath.row].saveNumber)
+        if let data = themeDetailData?.themeGame[indexPath.row] {
+            cell.configure(image: data.imageURL, name: data.name, info: data.intro, star: data.star, save: data.saveCount)
+        }
         
         return cell
     }
@@ -116,7 +126,10 @@ extension ThemeVC: UICollectionViewDataSource {
         
         let headerview = collectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: "ThemeCollectionReusableView", for: indexPath) as! ThemeCollectionReusableView
         
-        headerview.setTheme(info: "✋은 👀보다 빠르다", title: "내가 이 구역 최고 브레인!")
+        if let data = themeDetailData?.themes[0] {
+            headerview.setTheme(info: data.detail, title: data.name, back: data.imageURL)
+        }
+        
         return headerview
     }
     

--- a/boardpedia/boardpedia/Screen/Main/VC/ThemeVC.swift
+++ b/boardpedia/boardpedia/Screen/Main/VC/ThemeVC.swift
@@ -12,7 +12,7 @@ class ThemeVC: UIViewController {
     // MARK: Variable Part
     
     var searchResultData: [SearchResultData] = []
-    var themeData: ThemeData?
+    var themeIdx: Int?
     
     // MARK: IBOutlet
     
@@ -23,10 +23,6 @@ class ThemeVC: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setResultCollectionView()
-        
-        if let data = themeData {
-            print(data)
-        }
     }
     
     
@@ -39,13 +35,6 @@ extension ThemeVC {
     // MARK: Result Data Style Function
     
     func setResultCollectionView() {
-        
-        // Test Data (서버 연결 전)
-        let themeItem1 = SearchResultData(gameImage: "testImage", gameName: "할리갈리 디럭스", gameInfo: "벨과 함께 즐기는 스릴감", saveNumber: 100, startNumber: 4.5, bookMark: false)
-        let themeItem2 = SearchResultData(gameImage: "testImage", gameName: "오늘의 일기 김민희", gameInfo: "오늘은 굉장히 더운날이다. 미쳤다. 여름에는 얼마나 더울까?", saveNumber: 98, startNumber: 3, bookMark: true)
-        
-        searchResultData.append(contentsOf: [themeItem1,themeItem1,themeItem1,themeItem1,themeItem1,themeItem1,themeItem1,themeItem2])
-        
         
         themeListCollectionView.delegate = self
         themeListCollectionView.dataSource = self

--- a/boardpedia/boardpedia/Screen/Main/VC/ThemeVC.swift
+++ b/boardpedia/boardpedia/Screen/Main/VC/ThemeVC.swift
@@ -12,6 +12,7 @@ class ThemeVC: UIViewController {
     // MARK: Variable Part
     
     var searchResultData: [SearchResultData] = []
+    var themeDetailData: ThemeDetailData?
     var themeIdx: Int?
     
     // MARK: IBOutlet
@@ -39,6 +40,24 @@ extension ThemeVC {
         themeListCollectionView.delegate = self
         themeListCollectionView.dataSource = self
         themeListCollectionView.backgroundColor = .boardGray
+        
+        if let token = UserDefaults.standard.string(forKey: "UserToken"),
+           let index = themeIdx {
+            APIService.shared.todayThemeDetail(token, index) { [self] result in
+                switch result {
+                
+                case .success(let data):
+                    themeDetailData = data
+                    
+                case .failure(let error):
+                    print(error)
+                    
+                }
+                
+            }
+            
+        }
+        //todayThemeDetail
     }
 }
 

--- a/boardpedia/boardpedia/Screen/Main/VC/ThemeVC.swift
+++ b/boardpedia/boardpedia/Screen/Main/VC/ThemeVC.swift
@@ -128,6 +128,7 @@ extension ThemeVC: UICollectionViewDataSource {
         
         if let data = themeDetailData?.themes[0] {
             headerview.setTheme(info: data.detail, title: data.name, back: data.imageURL)
+            headerview.setTag(tag: data.tag)
         }
         
         headerview.backButtonAction = {

--- a/boardpedia/boardpedia/Screen/Main/VC/ThemeVC.swift
+++ b/boardpedia/boardpedia/Screen/Main/VC/ThemeVC.swift
@@ -130,6 +130,12 @@ extension ThemeVC: UICollectionViewDataSource {
             headerview.setTheme(info: data.detail, title: data.name, back: data.imageURL)
         }
         
+        headerview.backButtonAction = {
+            // closure 호출
+            
+            self.navigationController?.popViewController(animated: true)
+        }
+        
         return headerview
     }
     

--- a/boardpedia/boardpedia/Screen/Main/VC/ThemeVC.swift
+++ b/boardpedia/boardpedia/Screen/Main/VC/ThemeVC.swift
@@ -12,6 +12,7 @@ class ThemeVC: UIViewController {
     // MARK: Variable Part
     
     var searchResultData: [SearchResultData] = []
+    var themeData: ThemeData?
     
     // MARK: IBOutlet
     
@@ -22,6 +23,10 @@ class ThemeVC: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setResultCollectionView()
+        
+        if let data = themeData {
+            print(data)
+        }
     }
     
     

--- a/boardpedia/boardpedia/Screen/Mypage/VC/MySaveListVC.swift
+++ b/boardpedia/boardpedia/Screen/Mypage/VC/MySaveListVC.swift
@@ -14,7 +14,6 @@ class MySaveListVC: UIViewController {
     var saveListData: [UserSaveListData] = [] {
         didSet {
             if saveListData.count == 0 {
-                print("커노")
                 // 데이터가 없는 경우
                 if UserDefaults.standard.string(forKey: "UserSnsId") == "1234567" {
                     // 비회원이라면


### PR DESCRIPTION
## Task
- [x] 메인 홈에서 받아온 id 값을 전달
- [x] id값을 가지고 테마 상세보기 api 연결
- [x] api 연결 후 화면에 보여주기
- [x] 홈 - 테마 상세보기 뷰 연결
- [x] 북마크 기능 연결

## 관계된 이슈, PR :  
#41 

## Zepline 스크린샷  
<img width="400" alt="스크린샷 2021-07-25 오전 1 43 27" src="https://user-images.githubusercontent.com/51286963/126875321-a5cd8d1a-306b-4add-a41b-ec35042471f2.png">


### 기기별 스크린 샷
iphone12ProMax | iphone12mini | iphoneSE  |
:---: | :---: | :---:
<img width="250" src="https://user-images.githubusercontent.com/51286963/126875304-b35fb3ae-97e2-4d9f-a318-bc721d09edd4.png"> | <img width="250" src="https://user-images.githubusercontent.com/51286963/126875278-f95a7ca8-e0db-4850-81d8-f95c0826b25a.png"> | <img width="250" src="https://user-images.githubusercontent.com/51286963/126875297-4957b092-d4e4-472f-9c24-0309f9d22de1.png">


## 참고 레퍼런스  
- 클로저를 이용해 navigation pop을 구현해봤다!
