### PR TITLE
[network][feat] 보드게임 모아보기 - 서버 연결 및 기능 추가

### DIFF
--- a/boardpedia/boardpedia.xcodeproj/project.pbxproj
+++ b/boardpedia/boardpedia.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		9B634A472682355E005ADCC3 /* TabBarVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B634A462682355E005ADCC3 /* TabBarVC.swift */; };
 		9B652C5326AC3E9C00DC7931 /* ThemeDetailData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B652C5226AC3E9C00DC7931 /* ThemeDetailData.swift */; };
 		9B652C5826AC7DD600DC7931 /* GameCollectionData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B652C5726AC7DD600DC7931 /* GameCollectionData.swift */; };
+		9B652C5B26AD264800DC7931 /* UIViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B652C5A26AD264800DC7931 /* UIViewController+Extension.swift */; };
 		9B7F182E2666277B00BD29CC /* GameDetailData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B7F182D2666277B00BD29CC /* GameDetailData.swift */; };
 		9B7F18332668AF7400BD29CC /* SimilarGameCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B7F18322668AF7400BD29CC /* SimilarGameCell.swift */; };
 		9B7F18362668C88800BD29CC /* GameReviewVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B7F18352668C88800BD29CC /* GameReviewVC.swift */; };
@@ -142,6 +143,7 @@
 		9B634A462682355E005ADCC3 /* TabBarVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarVC.swift; sourceTree = "<group>"; };
 		9B652C5226AC3E9C00DC7931 /* ThemeDetailData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeDetailData.swift; sourceTree = "<group>"; };
 		9B652C5726AC7DD600DC7931 /* GameCollectionData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameCollectionData.swift; sourceTree = "<group>"; };
+		9B652C5A26AD264800DC7931 /* UIViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extension.swift"; sourceTree = "<group>"; };
 		9B7F182D2666277B00BD29CC /* GameDetailData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameDetailData.swift; sourceTree = "<group>"; };
 		9B7F18322668AF7400BD29CC /* SimilarGameCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimilarGameCell.swift; sourceTree = "<group>"; };
 		9B7F18352668C88800BD29CC /* GameReviewVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameReviewVC.swift; sourceTree = "<group>"; };
@@ -411,6 +413,7 @@
 				9BE098DF26498C52007D2BEC /* UITextField+Extension.swift */,
 				9B7F184D2668F8EF00BD29CC /* String+Extension.swift */,
 				9B2941872679CACB0008F69F /* UIImageView+Extension.swift */,
+				9B652C5A26AD264800DC7931 /* UIViewController+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -725,6 +728,7 @@
 				9B4ACDDA266B6ADC00381416 /* GenericResponse.swift in Sources */,
 				9B09111F265C05F100FB5928 /* ThemeGameListCell.swift in Sources */,
 				9B162C4C264ADC7600219529 /* MyReviewListVC.swift in Sources */,
+				9B652C5B26AD264800DC7931 /* UIViewController+Extension.swift in Sources */,
 				9B41FA912644FC16002A3E13 /* UIButton+Extension.swift in Sources */,
 				9B09110C265BEEBA00FB5928 /* ThemeVC.swift in Sources */,
 				9B652C5826AC7DD600DC7931 /* GameCollectionData.swift in Sources */,

--- a/boardpedia/boardpedia.xcodeproj/project.pbxproj
+++ b/boardpedia/boardpedia.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		9B634A442682352F005ADCC3 /* TabBar.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9B634A432682352F005ADCC3 /* TabBar.storyboard */; };
 		9B634A472682355E005ADCC3 /* TabBarVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B634A462682355E005ADCC3 /* TabBarVC.swift */; };
 		9B652C5326AC3E9C00DC7931 /* ThemeDetailData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B652C5226AC3E9C00DC7931 /* ThemeDetailData.swift */; };
+		9B652C5826AC7DD600DC7931 /* GameCollectionData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B652C5726AC7DD600DC7931 /* GameCollectionData.swift */; };
 		9B7F182E2666277B00BD29CC /* GameDetailData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B7F182D2666277B00BD29CC /* GameDetailData.swift */; };
 		9B7F18332668AF7400BD29CC /* SimilarGameCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B7F18322668AF7400BD29CC /* SimilarGameCell.swift */; };
 		9B7F18362668C88800BD29CC /* GameReviewVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B7F18352668C88800BD29CC /* GameReviewVC.swift */; };
@@ -140,6 +141,7 @@
 		9B634A432682352F005ADCC3 /* TabBar.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = TabBar.storyboard; sourceTree = "<group>"; };
 		9B634A462682355E005ADCC3 /* TabBarVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarVC.swift; sourceTree = "<group>"; };
 		9B652C5226AC3E9C00DC7931 /* ThemeDetailData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeDetailData.swift; sourceTree = "<group>"; };
+		9B652C5726AC7DD600DC7931 /* GameCollectionData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameCollectionData.swift; sourceTree = "<group>"; };
 		9B7F182D2666277B00BD29CC /* GameDetailData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameDetailData.swift; sourceTree = "<group>"; };
 		9B7F18322668AF7400BD29CC /* SimilarGameCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimilarGameCell.swift; sourceTree = "<group>"; };
 		9B7F18352668C88800BD29CC /* GameReviewVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameReviewVC.swift; sourceTree = "<group>"; };
@@ -383,6 +385,7 @@
 				9B140E7D268B4EE6003421F2 /* UserData.swift */,
 				9B140E82268B5C06003421F2 /* UserSaveListData.swift */,
 				D2AF055B268EE0A900E71138 /* UserReviewListData.swift */,
+				9B652C5726AC7DD600DC7931 /* GameCollectionData.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -724,6 +727,7 @@
 				9B162C4C264ADC7600219529 /* MyReviewListVC.swift in Sources */,
 				9B41FA912644FC16002A3E13 /* UIButton+Extension.swift in Sources */,
 				9B09110C265BEEBA00FB5928 /* ThemeVC.swift in Sources */,
+				9B652C5826AC7DD600DC7931 /* GameCollectionData.swift in Sources */,
 				9BE098F8264A4FD9007D2BEC /* SearchResultVC.swift in Sources */,
 				9B7F184E2668F8EF00BD29CC /* String+Extension.swift in Sources */,
 				9B7F18482668F2A000BD29CC /* CollectionViewCenterLayout.swift in Sources */,

--- a/boardpedia/boardpedia/Global/Extension/UIViewController+Extension.swift
+++ b/boardpedia/boardpedia/Global/Extension/UIViewController+Extension.swift
@@ -1,0 +1,43 @@
+//
+//  UIViewController+Extension.swift
+//  boardpedia
+//
+//  Created by 김민희 on 2021/07/25.
+//
+
+import UIKit
+
+
+extension UIViewController {
+    
+    // MARK: Toast Alert Extension
+    
+    func showToast(message : String, font: UIFont, width: Int, bottomY: Int) {
+        let guide = view.safeAreaInsets.bottom
+        let y = self.view.frame.size.height-guide
+        
+        let toastLabel = UILabel(
+            frame: CGRect( x: self.view.frame.size.width/2 - CGFloat(width)/2,
+                           y: y-CGFloat(bottomY),
+                           width: CGFloat(width),
+                           height: 40
+            )
+        )
+        
+        toastLabel.backgroundColor = UIColor.darkGray
+        toastLabel.textColor = UIColor.boardOrange
+        toastLabel.font = font
+        toastLabel.textAlignment = .center
+        toastLabel.text = message
+        toastLabel.alpha = 1.0
+        toastLabel.layer.cornerRadius = 6
+        toastLabel.clipsToBounds  =  true
+        self.view.addSubview(toastLabel)
+        UIView.animate(withDuration: 1.2, delay: 0.7, options: .curveEaseOut, animations: {
+            toastLabel.alpha = 0.0
+        }, completion: {(isCompleted) in
+            toastLabel.removeFromSuperview()
+        })
+    }
+}
+

--- a/boardpedia/boardpedia/Global/Model/GameCollectionData.swift
+++ b/boardpedia/boardpedia/Global/Model/GameCollectionData.swift
@@ -1,0 +1,13 @@
+//
+//  GameCollectionData.swift
+//  boardpedia
+//
+//  Created by 김민희 on 2021/07/25.
+//
+
+import Foundation
+
+struct GameCollectionData: Codable {
+    let totalNum: Int
+    let searchedGame: [SearchGameData]
+}

--- a/boardpedia/boardpedia/Global/Model/SearchGameData.swift
+++ b/boardpedia/boardpedia/Global/Model/SearchGameData.swift
@@ -10,7 +10,8 @@ import Foundation
 struct SearchGameData: Codable {
     let gameIdx: Int
     let name, intro, imageURL: String
-    let saved, saveCount: Int
+    var saved: Int
+    let saveCount: Int
     let star: Double
 
     enum CodingKeys: String, CodingKey {

--- a/boardpedia/boardpedia/Global/Service/APIService.swift
+++ b/boardpedia/boardpedia/Global/Service/APIService.swift
@@ -92,6 +92,14 @@ struct APIService {
         
     }
     
+    func getGameCollection(_ jwt: String,_ pageIdx: Int, _ playerNum: Int, _ level: String, _ tag: [String], _ duration: String, completion: @escaping (NetworkResult<GameCollectionData>)->(Void)) {
+        // 게임 모아보기 조회
+        
+        let target: APITarget = .getFilterGame(jwt: jwt, pageIdx: pageIdx, playerNum: playerNum, level: level, tag: tag, duration: duration)
+        judgeObject(target, completion: completion)
+        
+    }
+    
     
 }
 

--- a/boardpedia/boardpedia/Screen/Collect/Cell/GameCollectionCell.swift
+++ b/boardpedia/boardpedia/Screen/Collect/Cell/GameCollectionCell.swift
@@ -37,9 +37,9 @@ class GameCollectionCell: UICollectionViewCell {
     
     // MARK: Data Set Function
     
-    func configure(image: String, name: String, info: String, star: Float, save: Int) {
+    func configure(image: String, name: String, info: String, star: Double, save: Int) {
 
-        gameImageView.image = UIImage(named: image)
+        gameImageView.setImage(from: image)
         gameNameLabel.setLabel(text: name, font: .neoMedium(ofSize: 16))
         gameInfoLabel.setLabel(text: info, color: .boardGray50, font: .neoRegular(ofSize: 13))
         gameValueLabel.setLabel(text: "별점 \(star) / 저장 \(save)회", color: .boardGray40, font: .neoMedium(ofSize: 12))

--- a/boardpedia/boardpedia/Screen/Collect/Cell/GameCollectionCell.swift
+++ b/boardpedia/boardpedia/Screen/Collect/Cell/GameCollectionCell.swift
@@ -12,6 +12,9 @@ class GameCollectionCell: UICollectionViewCell {
     // MARK: Variable Part
     
     static let identifier = "GameCollectionCell"
+    var cellDelegate: BookmarkCellDelegate?
+    var cellIndex: IndexPath?
+    var impactFeedbackGenerator: UIImpactFeedbackGenerator?
     
     // MARK: IBOutlet
     
@@ -21,11 +24,23 @@ class GameCollectionCell: UICollectionViewCell {
     @IBOutlet weak var bookmarkButton: UIButton!
     @IBOutlet weak var gameValueLabel: UILabel!
     
+    // MARK: IBAction
+    
+    @IBAction func bookmarkButtonDidTap(_ sender: Any) {
+        
+        cellDelegate?.BookmarkCellGiveIndex(self, didClickedIndex: cellIndex?.row ?? 0)
+        self.impactFeedbackGenerator?.impactOccurred()
+        
+    }
+    
     // MARK: ContentView Default Set Function
     
     override func awakeFromNib() {
+        
         super.awakeFromNib()
         // Initialization code
+        
+        self.impactFeedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
         
         self.contentView.backgroundColor = .boardWhite
         self.contentView.setRounded(radius: 6)

--- a/boardpedia/boardpedia/Screen/Collect/Cell/GameCollectionCell.xib
+++ b/boardpedia/boardpedia/Screen/Collect/Cell/GameCollectionCell.xib
@@ -29,6 +29,9 @@
                             <constraint firstAttribute="width" secondItem="Rp5-55-EMF" secondAttribute="height" multiplier="1:1" id="7aZ-i3-tUD"/>
                         </constraints>
                         <state key="normal" image="icStorageUnselected"/>
+                        <connections>
+                            <action selector="bookmarkButtonDidTap:" destination="gTV-IL-0wX" eventType="touchUpInside" id="nb6-QT-8lU"/>
+                        </connections>
                     </button>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Whi-iW-SrR">
                         <rect key="frame" x="153" y="15" width="86.5" height="21"/>

--- a/boardpedia/boardpedia/Screen/Collect/Storyboard/GameCollect.storyboard
+++ b/boardpedia/boardpedia/Screen/Collect/Storyboard/GameCollect.storyboard
@@ -100,7 +100,7 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="DrY-fp-t5d">
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" bouncesZoom="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="DrY-fp-t5d">
                                 <rect key="frame" x="0.0" y="205" width="414" height="691"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="XtO-lh-b8L">

--- a/boardpedia/boardpedia/Screen/Collect/VC/GameCollectVC.swift
+++ b/boardpedia/boardpedia/Screen/Collect/VC/GameCollectVC.swift
@@ -108,13 +108,14 @@ extension GameCollectVC {
     }
     
     func getGameData(jwt: String, pageIdx: Int, playerNum: Int, level: String, tag: [String], duration: String) {
+        // 서버 연결 함수 : 게임 데이터 받아오기
         
         APIService.shared.getGameCollection(jwt, pageIdx, playerNum, level, tag, duration) { [self] result in
             switch result {
             
             case .success(let data):
                 totalGameCount = data.totalNum
-                searchResultData.append(contentsOf: data.searchedGame)
+                searchResultData.insert(contentsOf: data.searchedGame, at: pageIdx*10)
                 gameCollectionView.reloadData()
                 isPaging = false
                 

--- a/boardpedia/boardpedia/Screen/Collect/VC/GameCollectVC.swift
+++ b/boardpedia/boardpedia/Screen/Collect/VC/GameCollectVC.swift
@@ -76,6 +76,8 @@ extension GameCollectVC {
         gameCollectionView.delegate = self
         gameCollectionView.dataSource = self
         gameCollectionView.backgroundColor = .boardGray
+        
+        initRefresh()
     }
     
     func setFilterCollectionView() {
@@ -115,7 +117,13 @@ extension GameCollectVC {
             
             case .success(let data):
                 totalGameCount = data.totalNum
-                searchResultData.insert(contentsOf: data.searchedGame, at: pageIdx*10)
+                
+                if pageIdx == 0 {
+                    searchResultData = data.searchedGame
+                } else {
+                    searchResultData.insert(contentsOf: data.searchedGame, at: pageIdx*10)
+                }
+                
                 gameCollectionView.reloadData()
                 isPaging = false
                 
@@ -123,6 +131,31 @@ extension GameCollectVC {
                 print(error)
                 
             }
+        }
+        
+    }
+    
+    // MARK: CollectionView Data Refresh Function
+    
+    func initRefresh() {
+        
+        let refresh = UIRefreshControl()
+        refresh.addTarget(self, action: #selector(updateData(refresh:)), for: .valueChanged)
+        
+        gameCollectionView.addSubview(refresh)
+    }
+    
+    // MARK: Run On CollecionView Refresh Function
+    
+    @objc func updateData(refresh: UIRefreshControl) {
+        
+        refresh.endRefreshing()
+        
+        pageIdx = 0
+        
+        if let token = UserDefaults.standard.string(forKey: "UserToken") {
+          getGameData(jwt: token, pageIdx: pageIdx, playerNum: 0, level: "", tag: [], duration: "")
+            
         }
         
     }

--- a/boardpedia/boardpedia/Screen/Collect/VC/GameCollectVC.swift
+++ b/boardpedia/boardpedia/Screen/Collect/VC/GameCollectVC.swift
@@ -255,3 +255,68 @@ extension GameCollectVC: UIScrollViewDelegate {
         
     }
 }
+
+
+
+extension GameCollectVC: BookmarkCellDelegate {
+    func BookmarkCellGiveIndex(_ cell: UICollectionViewCell, didClickedIndex value: Int) {
+        
+        
+        if UserDefaults.standard.string(forKey: "UserSnsId") == "1234567" {
+            // 비회원이라면 -> 로그인 하라는 창으로 이동
+        
+            let nextStoryboard = UIStoryboard(name: "Login", bundle: nil)
+            guard let popUpVC = nextStoryboard.instantiateViewController(identifier: "LoginPopupVC") as? LoginPopupVC else { return }
+            
+            self.present(popUpVC, animated: true, completion: nil)
+            // 로그인 유도 팝업 띄우기
+            
+            
+        } else {
+            // 회원 로그인을 했다면
+            
+            if let token = UserDefaults.standard.string(forKey: "UserToken") {
+                // 토큰 존재 시
+                
+                if searchResultData[value].saved == 0 {
+                    // 미저장 -> 저장으로 변경
+                    
+                    APIService.shared.saveGame(token, searchResultData[value].gameIdx) { [self] result in
+                        switch result {
+                        
+                        case .success(_):
+                            
+                            searchResultData[value].saved = 1
+                            gameCollectionView.reloadData()
+                            
+                        case .failure(let error):
+                            print(error)
+                            
+                        }
+                        
+                    }
+                } else {
+                    // 저장 -> 미저장으로 변경
+                    
+                    APIService.shared.saveCancleGame(token, searchResultData[value].gameIdx) { [self] result in
+                        switch result {
+                        
+                        case .success(_):
+                            
+                            searchResultData[value].saved = 0
+                            gameCollectionView.reloadData()
+                            
+                        case .failure(let error):
+                            print(error)
+                            
+                        }
+                        
+                    }
+                    
+                }
+                
+            }
+            
+        }
+    }
+}

--- a/boardpedia/boardpedia/Screen/Collect/VC/GameCollectVC.swift
+++ b/boardpedia/boardpedia/Screen/Collect/VC/GameCollectVC.swift
@@ -19,7 +19,7 @@ class GameCollectVC: UIViewController {
             setResultLabel()
         }
     }
-
+    var isPaging: Bool = false
     
     // MARK: IBOutlet
     
@@ -116,6 +116,7 @@ extension GameCollectVC {
                 totalGameCount = data.totalNum
                 searchResultData.append(contentsOf: data.searchedGame)
                 gameCollectionView.reloadData()
+                isPaging = false
                 
             case .failure(let error):
                 print(error)
@@ -225,4 +226,32 @@ extension GameCollectVC: UICollectionViewDataSource {
         
     }
     
+}
+
+extension GameCollectVC: UIScrollViewDelegate {
+    
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        
+        let offsetY = scrollView.contentOffset.y
+        let contentHeight = scrollView.contentSize.height
+        let height = scrollView.frame.height
+        
+        if offsetY > (contentHeight - height) && !isPaging {
+            isPaging = true
+            
+            if (totalGameCount - searchResultData.count) > 0 {
+                // 아직 가져올 데이터가 남았다면
+                
+                pageIdx += 1
+                
+                if let token = UserDefaults.standard.string(forKey: "UserToken") {
+                    getGameData(jwt: token, pageIdx: pageIdx, playerNum: 0, level: "", tag: [], duration: "")
+                    
+                }
+                
+            }
+            
+        }
+        
+    }
 }

--- a/boardpedia/boardpedia/Screen/Collect/VC/GameCollectVC.swift
+++ b/boardpedia/boardpedia/Screen/Collect/VC/GameCollectVC.swift
@@ -211,6 +211,9 @@ extension GameCollectVC: UICollectionViewDataSource {
             
             cell.configure(image: searchResultData[indexPath.row].imageURL, name: searchResultData[indexPath.row].name, info: searchResultData[indexPath.row].intro, star: searchResultData[indexPath.row].star, save: searchResultData[indexPath.row].saveCount)
             
+            cell.cellDelegate = self
+            cell.cellIndex = indexPath
+            
             return cell
             
         } else {

--- a/boardpedia/boardpedia/Screen/Main/VC/ThemeVC.swift
+++ b/boardpedia/boardpedia/Screen/Main/VC/ThemeVC.swift
@@ -196,6 +196,7 @@ extension ThemeVC: BookmarkCellDelegate {
                             case .success(_):
                                 
                                 getThemeGame(token: token, index: index)
+                                showToast(message: "북마크 완료 🧡", font: .neoBold(ofSize: 15), width: 188, bottomY: 50)
                                 
                             case .failure(let error):
                                 print(error)
@@ -212,6 +213,7 @@ extension ThemeVC: BookmarkCellDelegate {
                             case .success(_):
                                 
                                 getThemeGame(token: token, index: index)
+                                showToast(message: "저장 목록에서 삭제되었어요", font: .neoBold(ofSize: 15), width: 200, bottomY: 50)
                                 
                             case .failure(let error):
                                 print(error)

--- a/boardpedia/boardpedia/Screen/Main/VC/ThemeVC.swift
+++ b/boardpedia/boardpedia/Screen/Main/VC/ThemeVC.swift
@@ -25,6 +25,13 @@ class ThemeVC: UIViewController {
         setResultCollectionView()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        if let token = UserDefaults.standard.string(forKey: "UserToken"),
+           let index = themeIdx {
+            // 테마 받아오는 서버 연결
+            getThemeGame(token: token, index: index)
+        }
+    }
     
 }
 
@@ -39,12 +46,6 @@ extension ThemeVC {
         themeListCollectionView.delegate = self
         themeListCollectionView.dataSource = self
         themeListCollectionView.backgroundColor = .boardGray
-        
-        if let token = UserDefaults.standard.string(forKey: "UserToken"),
-           let index = themeIdx {
-            // 테마 받아오는 서버 연결
-            getThemeGame(token: token, index: index)
-        }
     }
     
     func getThemeGame(token: String, index: Int) {


### PR DESCRIPTION
## Task
- [x] 모드게임 모아보기 탭 api 연결
- [x] 서버 데이터 화면에 띄우기 성공
- [x] 북마크 클릭 시 북마크 서버 연결 기능 추가
- [x] pagination 기능 추가

## 관계된 이슈, PR :  
#43 

## Zepline 스크린샷  
<img width="430" alt="스크린샷 2021-07-25 오후 2 15 41" src="https://user-images.githubusercontent.com/51286963/126888537-475e7b89-394a-4562-8cec-16855060727a.png">


### 기기별 스크린 샷
iphone12ProMax | iphone12mini | iphoneSE  |
:---: | :---: | :---:
<img width="250" src="https://user-images.githubusercontent.com/51286963/126888513-030c1459-9eec-403f-8b89-e217beefbe9c.png"> | <img width="250" src="https://user-images.githubusercontent.com/51286963/126888524-2ef5d81a-7515-4016-9ec4-f5e2fb722622.png"> | <img width="250" src="https://user-images.githubusercontent.com/51286963/126888530-8e382476-86ed-498d-95a8-fc095eb3c06e.png">


## 참고 내용
- api 서버 오류가 있어서 세화에게 말해둔 상태 -> 변경된 후 다시 봐보기
- 다른 뷰와의 북마크 연결을 다르게 구현해보자...


